### PR TITLE
Add custom tools based on AGENT_NAME variable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 src/__pycache__/
 __pycache__/
+demos/
 venv/
 .env

--- a/prompts/globalKyc.txt
+++ b/prompts/globalKyc.txt
@@ -1,4 +1,10 @@
 Cutting Knowledge Date: December 2023
 Today Date: {datetime.datetime.today().strftime("%d %B %Y")}
 
-Your name is Alex. You work as a data analyst at Global KYC.
+You are an assistant working at Global KYC. Your role is to help users by answering their questions and fulfilling their requests.
+
+You have access to the following tools:
+- `design_leasing_offer`: Use this if the user explicitly asks you to design a leasing offer for a customer.
+- `categorize_zone`: Use this if the user explicitly asks you to categorize a city as URBAN or RURAL.
+
+Be helpful, clear, and professional in your responses. You can use emojis, if you like.

--- a/src/app.py
+++ b/src/app.py
@@ -1,20 +1,24 @@
 # app.py
 
-from llama_index.core.agent.workflow import ToolCallResult, AgentStream
-from llama_index.core.workflow import Context
-
-from demo_agent import DemoAgent
-from multimodal import stt
-
-from streamlit_mic_recorder import mic_recorder
-import streamlit as st
-
 import tempfile
 import asyncio
 import time
 import json
+import sys
 import os
 import io
+
+from llama_index.core.agent.workflow import ToolCallResult, AgentStream
+from llama_index.core.workflow import Context
+
+from streamlit_mic_recorder import mic_recorder
+import streamlit as st
+
+# Add the parent directory (project root) to sys.path
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from src.demo_agent import DemoAgent
+from src.multimodal import stt
 
 # Set page title and favicon
 st.set_page_config(

--- a/src/custom_tools.py
+++ b/src/custom_tools.py
@@ -1,1 +1,0 @@
-# custom_tools.py

--- a/src/demo_agent.py
+++ b/src/demo_agent.py
@@ -1,10 +1,15 @@
 # demo_agent.py
 
+from dotenv import load_dotenv
+from pathlib import Path
+import importlib
+import warnings
+import inspect
+import sys
+import os
+
 from llama_index.core.agent.workflow import CodeActAgent
 from llama_index.llms.groq import Groq as LlamaGroq
-
-from base_tools import transcribe_audio, analyze_image
-from code_executor import SimpleCodeExecutor
 
 import matplotlib.pyplot as plt
 import pandas as pd
@@ -12,59 +17,93 @@ import numpy as np
 import datetime
 import re
 
-from dotenv import load_dotenv
-from pathlib import Path
-import os
+# Add the parent directory (project root) to sys.path
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
+from src.code_executor import SimpleCodeExecutor
+
+# Load env variavbles
 load_dotenv()
-SYSTEM_PROMPT_KEY = os.getenv("SYSTEM_PROMPT_KEY")
-API_KEY = os.getenv("API_KEY")
+AGENT_NAME = os.getenv("AGENT_NAME", "base")
+GROK_API_KEY = os.getenv("GROK_API_KEY")
 LLM = os.getenv("LLM")
 
 # LLM
 llm = LlamaGroq(
-    api_key=API_KEY,
+    api_key=GROK_API_KEY,
     model=LLM,
-    presence_penalty=0.5,
-    temperature=0.25,
-    top_p=0.9,
-    top_k=20,
-    min_p=0,
+    #presence_penalty=0.5,
+    #temperature=0.25,
+    #top_p=0.9,
+    #top_k=20,
+    #min_p=0,
     )
 
-# Code executor
-code_executor = SimpleCodeExecutor(
-    locals={
-    "transcribe_audio": transcribe_audio,
-    "analyze_image": analyze_image
-    },
-    globals={
-    "__builtins__": __builtins__,
-    "datetime": __import__("datetime"),
-    "matplotlib": __import__("matplotlib"),
-    "pd": __import__("pandas"),
-    "np": __import__("numpy"),
-    "re": __import__("re"),
-    },
-    )
+def load_agent_tools():
+    """Load agent tools."""
+    def get_module_functions(module_name):
+        try:
+            mod = importlib.import_module(module_name)
+            return {
+                name: obj for name, obj in inspect.getmembers(mod, inspect.isfunction)
+                if obj.__module__ == mod.__name__
+            }
+        except ModuleNotFoundError:
+            warnings.warn(f"[WARN] Module '{module_name}' not found.")
+            return {}
 
-# System prompt
-current_dir = Path(__file__).parent
-file_path = current_dir.parent / "prompts" / (SYSTEM_PROMPT_KEY+".txt")
+    # Always load base tools
+    tools_dict = get_module_functions("tools.base_tools")
 
-with open(file_path, "r") as file: content = file.read()
-system_prompt = eval(f"f'''{content}'''")
+    # Load custom tools if AGENT_NAME is set
+    if AGENT_NAME != "base":
+        custom_module = f"tools.custom_tools_{AGENT_NAME}"
+        custom_tools = get_module_functions(custom_module)
+
+        # Override or extend the base tools
+        tools_dict.update(custom_tools)
+    else: 
+        warnings.warn(f"[WARN] Base agent has no custom tools.")
+
+    return tools_dict
+
+def build_code_executor_fn():
+    """Build code executor function."""
+    code_executor = SimpleCodeExecutor(
+        locals=load_agent_tools(),
+        globals={
+        "__builtins__": __builtins__,
+        "datetime": __import__("datetime"),
+        "matplotlib": __import__("matplotlib"),
+        "pd": __import__("pandas"),
+        "np": __import__("numpy"),
+        "re": __import__("re"),
+        },
+        )
+    return code_executor.execute
+
+def get_system_prompt():
+    """Load and format system prompt."""
+    current_dir = Path(__file__).parent
+    file_path = current_dir.parent / "prompts" / (AGENT_NAME+".txt")
+    try:
+        with open(file_path, "r") as file: 
+            content = file.read()
+        return eval(f"f'''{content}'''")
+    except Exception as e:
+        warnings.warn(f"[WARN] Could not load system prompt: {str(e)}")
+        return ""
 
 ## Agent Workflow ##
 class DemoAgent():
     def __init__(self):
         self._agent = CodeActAgent(
             llm=llm,
-            code_execute_fn=code_executor.execute,
-            tools=[transcribe_audio, analyze_image]
+            code_execute_fn=build_code_executor_fn(),
+            tools=list(load_agent_tools().values())
             )
 
-        self.system_prompt = system_prompt
+        self.system_prompt = get_system_prompt()
 
         self.additional_instructions = ""
 

--- a/src/multimodal.py
+++ b/src/multimodal.py
@@ -6,14 +6,14 @@ from dotenv import load_dotenv
 import os
 
 load_dotenv()
-API_KEY = os.getenv("API_KEY")
+GROK_API_KEY = os.getenv("GROK_API_KEY")
 STT = os.getenv("STT")
 
 def stt(audio_file) -> str:
     """Converts speech from an audio file into text."""
 
 	# Initialize the Groq client
-    client = GroqClient(api_key=API_KEY)
+    client = GroqClient(api_key=GROK_API_KEY)
     
     # Create a transcription of the audio file
     transcription = client.audio.transcriptions.create(

--- a/tools/base_tools.py
+++ b/tools/base_tools.py
@@ -10,7 +10,7 @@ import mimetypes
 import base64
 
 load_dotenv()
-API_KEY = os.getenv("API_KEY")
+GROK_API_KEY = os.getenv("GROK_API_KEY")
 STT = os.getenv("STT")
 VLM = os.getenv("VLM")
 
@@ -21,7 +21,7 @@ def transcribe_audio(path_to_audio: str) -> str:
     Args:
         path_to_audio (str): The path to the audio file to be transcribed.
     Returns:
-        json: The transcribed text content of the audio file in JSON.
+        str: The transcribed text content of the audio.
     """
     
     # Validate path
@@ -30,7 +30,7 @@ def transcribe_audio(path_to_audio: str) -> str:
         raise FileNotFoundError(f"No such audio file: {path}")
 
     # Initialize the Groq client
-    client = GroqClient(api_key=API_KEY) 
+    client = GroqClient(api_key=GROK_API_KEY) 
     
     # Open the audio file
     with open(path_to_audio, "rb") as audio_file:
@@ -38,11 +38,11 @@ def transcribe_audio(path_to_audio: str) -> str:
         transcription = client.audio.transcriptions.create(
             file=audio_file,
             model=STT,
-            response_format="json",
+            response_format="text",
             temperature=0.1
         )
 
-    return transcription
+    return transcription.strip()
 
 def analyze_image(path_to_image: str, question: str) -> str:
     """
@@ -73,7 +73,7 @@ def analyze_image(path_to_image: str, question: str) -> str:
     base64_image = encode_image(path_to_image)
 
     # Initialize the Groq client
-    client = GroqClient(api_key=API_KEY)
+    client = GroqClient(api_key=GROK_API_KEY)
     
     chat_completion = client.chat.completions.create(
         messages=[

--- a/tools/custom_tools_globalKyc.py
+++ b/tools/custom_tools_globalKyc.py
@@ -1,0 +1,133 @@
+# custom_tools_globalKyc.py
+
+from dotenv import load_dotenv
+import os
+
+import datetime
+import requests
+
+load_dotenv()
+NINJAS_API_KEY = os.getenv("NINJAS_API_KEY")
+
+def categorize_zone(city: str, country: str) -> str:
+    """
+    Categorizes a city as 'URBAN' or 'RURAL' based on population.
+
+    Args:
+    - city (str): Name of the city.
+    - country (str): Country code. For example: DO for Dominican Republic, AR for Argentina and GB for the UK.
+
+    Returns:
+    - str: 'URBAN' if population > 50,000, else 'RURAL'.
+    """
+    url = 'https://api.api-ninjas.com/v1/city'
+    headers = {'X-Api-Key': NINJAS_API_KEY}
+    params = {
+        'name': city,
+        'country': country
+    }
+
+    try:
+        response = requests.get(url, headers=headers, params=params)
+        response.raise_for_status()
+        data = response.json()
+
+        if data:
+            print(data)
+            population = data[0].get('population')
+            if population is not None:
+                return 'URBAN' if population > 50000 else 'RURAL'
+        # No match for request
+        return f"NO data is available for {city}, {country}."
+    except requests.exceptions.RequestException as e:
+        return f"API request error: {e}"
+
+def design_leasing_offer(
+    customer_id: str,
+    birthdate: str,
+    income: float,
+    city: str,
+    vehicle_year: int
+) -> dict:
+    """
+    Designs a leasing offer based on customer and vehicle information.
+
+    Parameters:
+    - customer_id (str): Can be either a license-plate, an id-number or a name.
+    - birthdate (str): Customer's date of birth in 'DD-MM-YYYY' format.
+    - income (float): Customer's monthly income.
+    - city (str): City of residence.
+    - vehicle_year (int): The year the customer's current vehicle was manufactured.
+
+    Returns:
+    - dict: A dictionary containing the leasing offer details or ineligibility reason.
+    """
+    current_year = datetime.datetime.now().year
+    vehicle_age = current_year - vehicle_year
+
+    birthdate = datetime.datetime.strptime(birthdate, "%d-%m-%Y")
+    today = datetime.datetime.today()
+    customer_age = today.year - birthdate.year - ((today.month, today.day) < (birthdate.month, birthdate.day))
+    
+    # Eligibility Check
+    if vehicle_age <= 5:
+        return {
+            "customer_id": customer_id,
+            "eligible": False,
+            "reason": "vehicle is less than or equal to 5 years old."
+        }
+
+    if customer_age < 18 or customer_age > 65:
+        return {
+            "customer_id": customer_id,
+            "eligible": False,
+            "reason": "customer age must be between 18 and 65."
+        }
+    
+    # Income Segmentation
+    if income < 10000:
+        income_segment = "low"
+        base_rate = 0.10
+    elif 10000 <= income < 100000:
+        income_segment = "medium"
+        base_rate = 0.20
+    else:
+        income_segment = "high"
+        base_rate = 0.30
+
+    # Zone Classification
+    zone_type = categorize_zone(city, "DO").lower()
+    if zone_type == "urban":
+        base_rate += 0.05  # 5% extra-charge for urban areas
+    elif zone_type == "rural":
+        pass
+    else: zone_type = "unknown"
+
+    # Monthly Payment Calculation
+    monthly_payment = base_rate * income
+
+    # Contract Term Determination
+    if income_segment == "low":
+        contract_term_years = 2
+    elif income_segment == "medium":
+        contract_term_years = 3
+    else:
+        contract_term_years = 5
+
+    # Residual Value Estimation (Assuming 10% of original value per year of age)
+    # Note: In a real scenario, this should be based on actual depreciation data.
+    base_value = 1_000_000
+    residual_value = max(0, 1 - (vehicle_age * 0.10)) * base_value
+
+    return {
+        "customer_id": customer_id,
+        "eligible": True,
+        "customer_age": customer_age,
+        "vehicle_age": vehicle_age,
+        "income_segment": income_segment,
+        "zone_type": zone_type,
+        "monthly_payment": round(monthly_payment, 2),
+        "contract_term_years": contract_term_years,
+        "residual_value": round(residual_value, 2),
+        "purchase_option": True
+    }


### PR DESCRIPTION
The AGENT_NAME environment variable allows you to configure a specific prompt and set of tools for a given agent, distinguishing it from others.

Base tools are always applied to all agents by default.

If no AGENT_NAME is specified, the base agent—with its default prompt and base tools—is used.